### PR TITLE
Add zoom support to group editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Po uruchomieniu aplikacji:
 5. Listy po prawej stronie można przewijać kółkiem myszy. Pola statyczne można dodawać w dowolnej liczbie i dla każdego wpisać własną wartość.
 6. Nad polem konfiguracji znajdziesz przyciski formatowania tekstu oraz wybór kolorów tekstu i tła zaznaczonego elementu.
 7. Suwak Zoom pozwala powiększać pole konfiguracji, a klawisz `Del` usuwa zaznaczony element i odznacza jego checkbox.
-8. W edytorze grup można również powiększać obszar roboczy skrótem `Ctrl` + kółko myszy; siatka zachowuje stały rozmiar niezależnie od przybliżenia w głównym edytorze.
+8. W edytorze grup można również powiększać obszar roboczy skrótem `Ctrl` + kółko myszy; siatka i kartka dopasowują się automatycznie i pozostają niezależne od przybliżenia w głównym edytorze.
 9. Układ dopasowuje się do rozmiaru okna, zachowując proporcje strony. Ostatnio zapisany rozmiar strony jest wczytywany przy kolejnym uruchomieniu.
 10. Zapisz konfigurację (zapamiętuje ostatni plik Excel i ustawienia pól) lub wygeneruj pliki PDF dla wszystkich wierszy Excela.
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ Po uruchomieniu aplikacji:
 5. Listy po prawej stronie można przewijać kółkiem myszy. Pola statyczne można dodawać w dowolnej liczbie i dla każdego wpisać własną wartość.
 6. Nad polem konfiguracji znajdziesz przyciski formatowania tekstu oraz wybór kolorów tekstu i tła zaznaczonego elementu.
 7. Suwak Zoom pozwala powiększać pole konfiguracji, a klawisz `Del` usuwa zaznaczony element i odznacza jego checkbox.
-8. Układ dopasowuje się do rozmiaru okna, zachowując proporcje strony. Ostatnio zapisany rozmiar strony jest wczytywany przy kolejnym uruchomieniu.
-9. Zapisz konfigurację (zapamiętuje ostatni plik Excel i ustawienia pól) lub wygeneruj pliki PDF dla wszystkich wierszy Excela.
+8. W edytorze grup można również powiększać obszar roboczy skrótem `Ctrl` + kółko myszy.
+9. Układ dopasowuje się do rozmiaru okna, zachowując proporcje strony. Ostatnio zapisany rozmiar strony jest wczytywany przy kolejnym uruchomieniu.
+10. Zapisz konfigurację (zapamiętuje ostatni plik Excel i ustawienia pól) lub wygeneruj pliki PDF dla wszystkich wierszy Excela.
 
 Wymagane biblioteki są instalowane automatycznie przy pierwszym uruchomieniu skryptu.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Po uruchomieniu aplikacji:
 5. Listy po prawej stronie można przewijać kółkiem myszy. Pola statyczne można dodawać w dowolnej liczbie i dla każdego wpisać własną wartość.
 6. Nad polem konfiguracji znajdziesz przyciski formatowania tekstu oraz wybór kolorów tekstu i tła zaznaczonego elementu.
 7. Suwak Zoom pozwala powiększać pole konfiguracji, a klawisz `Del` usuwa zaznaczony element i odznacza jego checkbox.
-8. W edytorze grup można również powiększać obszar roboczy skrótem `Ctrl` + kółko myszy.
+8. W edytorze grup można również powiększać obszar roboczy skrótem `Ctrl` + kółko myszy; siatka zachowuje stały rozmiar niezależnie od przybliżenia w głównym edytorze.
 9. Układ dopasowuje się do rozmiaru okna, zachowując proporcje strony. Ostatnio zapisany rozmiar strony jest wczytywany przy kolejnym uruchomieniu.
 10. Zapisz konfigurację (zapamiętuje ostatni plik Excel i ustawienia pól) lub wygeneruj pliki PDF dla wszystkich wierszy Excela.
 

--- a/pds_gui.py
+++ b/pds_gui.py
@@ -773,6 +773,10 @@ class GroupEditor(tk.Toplevel):
                 el.bg_visible = src.bg_visible
                 el.align = src.align
                 el.auto_font = src.auto_font
+            else:
+                el.width *= self.scale
+                el.height *= self.scale
+                el.font_size *= self.scale
         if pos is not None:
             el.x, el.y = pos[0] * self.scale, pos[1] * self.scale
         el.sync_canvas()


### PR DESCRIPTION
## Summary
- Allow zooming inside group editor via Ctrl+mouse wheel with min/max scale limits
- Scale grid, element geometry and font controls when zooming
- Persist group elements at original size regardless of zoom level and document shortcut in README

## Testing
- `python -m py_compile pds_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1b1b621b0832087779a0b874f8215