### PR TITLE
Fix page boundary overlap with zoom controls

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -73,6 +73,7 @@ class PDSGeneratorGUI(tk.Tk):
         self.snap_step = self.grid_size * self.scale
         self.history = []
         self.future = []
+        self.zoom_frame = None
         self.setup_ui()
         self.bind_all("<Control-z>", self.undo)
         self.bind_all("<Control-x>", self.redo)
@@ -152,11 +153,11 @@ class PDSGeneratorGUI(tk.Tk):
         self.canvas.bind("<B2-Motion>", self.pan_canvas)
         self.canvas.configure(scrollregion=(-self.margin, -self.margin, self.page_width + self.margin, self.page_height + self.margin))
 
-        zoom_frame = ttk.Frame(self.canvas_container)
-        zoom_frame.place(relx=1.0, rely=1.0, anchor="se", x=-5, y=-5)
-        ttk.Button(zoom_frame, text="Dopasuj", command=self.fit_to_window).pack(side="right")
+        self.zoom_frame = ttk.Frame(self.canvas_container)
+        self.zoom_frame.place(relx=1.0, rely=1.0, anchor="se", x=-5, y=-5)
+        ttk.Button(self.zoom_frame, text="Dopasuj", command=self.fit_to_window).pack(side="right")
         self.zoom_var = tk.StringVar(value="100%")
-        ttk.Label(zoom_frame, textvariable=self.zoom_var).pack(side="right", padx=5)
+        ttk.Label(self.zoom_frame, textvariable=self.zoom_var).pack(side="right", padx=5)
 
         right_container = ttk.Frame(self)
         right_container.pack(side="right", fill="y", padx=5, pady=5)
@@ -946,6 +947,9 @@ class PDSGeneratorGUI(tk.Tk):
     def resize_canvas(self, event=None):
         container_w = self.canvas_container.winfo_width()
         container_h = self.canvas_container.winfo_height()
+        if self.zoom_frame:
+            container_w -= self.zoom_frame.winfo_width()
+            container_h -= self.zoom_frame.winfo_height()
         if container_w <= 0 or container_h <= 0:
             return
         self.min_scale = min(1.0, container_w / self.page_width, container_h / self.page_height)
@@ -1055,6 +1059,9 @@ class PDSGeneratorGUI(tk.Tk):
         h = self.page_height * self.scale
         container_w = self.canvas_container.winfo_width()
         container_h = self.canvas_container.winfo_height()
+        if self.zoom_frame:
+            container_w -= self.zoom_frame.winfo_width()
+            container_h -= self.zoom_frame.winfo_height()
         if container_w <= 0 or container_h <= 0:
             return
         total_w = w + 2 * (self.margin + 20)
@@ -1110,6 +1117,9 @@ class PDSGeneratorGUI(tk.Tk):
     def fit_to_window(self):
         container_w = self.canvas_container.winfo_width()
         container_h = self.canvas_container.winfo_height()
+        if self.zoom_frame:
+            container_w -= self.zoom_frame.winfo_width()
+            container_h -= self.zoom_frame.winfo_height()
         if container_w <= 0 or container_h <= 0:
             return
         new_scale = min(container_w / self.page_width, container_h / self.page_height)

--- a/gui.py
+++ b/gui.py
@@ -972,14 +972,15 @@ class PDSGeneratorGUI(tk.Tk):
         # slightly without introducing large grey areas around it
         self.canvas_container.update_idletasks()
         self.margin = 20
-        self.canvas.configure(
-            scrollregion=(
-                -self.margin - 20,
-                -self.margin - 20,
-                w + self.margin + 20,
-                h + self.margin + 20,
-            )
-        )
+        extra_w = self.zoom_frame.winfo_width() if self.zoom_frame else 0
+        extra_h = self.zoom_frame.winfo_height() if self.zoom_frame else 0
+        visible_w = self.canvas_container.winfo_width() - extra_w
+        visible_h = self.canvas_container.winfo_height() - extra_h
+        scroll_w = max(w + 2 * (self.margin + 20), visible_w) + extra_w
+        scroll_h = max(h + 2 * (self.margin + 20), visible_h) + extra_h
+        left = -self.margin - 20
+        top = -self.margin - 20
+        self.canvas.configure(scrollregion=(left, top, left + scroll_w, top + scroll_h))
         self.canvas.create_rectangle(0, 0, w, h, fill="white", outline="", tags="page")
         # draw rulers background
         self.canvas.create_rectangle(0, -20, w, 0, fill="#e0e0e0", outline="black", tags="ruler")

--- a/gui.py
+++ b/gui.py
@@ -976,11 +976,13 @@ class PDSGeneratorGUI(tk.Tk):
         extra_h = self.zoom_frame.winfo_height() if self.zoom_frame else 0
         visible_w = self.canvas_container.winfo_width() - extra_w
         visible_h = self.canvas_container.winfo_height() - extra_h
-        scroll_w = max(w + 2 * (self.margin + 20), visible_w) + extra_w
-        scroll_h = max(h + 2 * (self.margin + 20), visible_h) + extra_h
-        left = -self.margin - 20
-        top = -self.margin - 20
-        self.canvas.configure(scrollregion=(left, top, left + scroll_w, top + scroll_h))
+        base_w = max(w + 2 * (self.margin + 20), visible_w)
+        base_h = max(h + 2 * (self.margin + 20), visible_h)
+        total_w = base_w + extra_w
+        total_h = base_h + extra_h
+        left = -(base_w - w) / 2 - extra_w / 2
+        top = -(base_h - h) / 2 - extra_h / 2
+        self.canvas.configure(scrollregion=(left, top, left + total_w, top + total_h))
         self.canvas.create_rectangle(0, 0, w, h, fill="white", outline="", tags="page")
         # draw rulers background
         self.canvas.create_rectangle(0, -20, w, 0, fill="#e0e0e0", outline="black", tags="ruler")
@@ -1060,17 +1062,18 @@ class PDSGeneratorGUI(tk.Tk):
         h = self.page_height * self.scale
         container_w = self.canvas_container.winfo_width()
         container_h = self.canvas_container.winfo_height()
-        if self.zoom_frame:
-            container_w -= self.zoom_frame.winfo_width()
-            container_h -= self.zoom_frame.winfo_height()
-        if container_w <= 0 or container_h <= 0:
+        extra_w = self.zoom_frame.winfo_width() if self.zoom_frame else 0
+        extra_h = self.zoom_frame.winfo_height() if self.zoom_frame else 0
+        visible_w = container_w - extra_w
+        visible_h = container_h - extra_h
+        if visible_w <= 0 or visible_h <= 0:
             return
-        total_w = w + 2 * (self.margin + 20)
-        total_h = h + 2 * (self.margin + 20)
-        left = self.margin + 20 + w / 2 - container_w / 2
-        top = self.margin + 20 + h / 2 - container_h / 2
-        left = max(0, min(left, total_w - container_w))
-        top = max(0, min(top, total_h - container_h))
+        base_w = max(w + 2 * (self.margin + 20), visible_w)
+        base_h = max(h + 2 * (self.margin + 20), visible_h)
+        total_w = base_w + extra_w
+        total_h = base_h + extra_h
+        left = (total_w - visible_w) / 2
+        top = (total_h - visible_h) / 2
         self.canvas.xview_moveto(left / total_w)
         self.canvas.yview_moveto(top / total_h)
     def ctrl_zoom(self, event, delta=None):


### PR DESCRIPTION
## Summary
- keep track of the zoom control frame and subtract its size when fitting or resizing the canvas
- center the page using the visible area so edges are no longer hidden

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5a0319e30832086761d0d5f27ed02