### PR TITLE
Improve canvas scrollregion handling

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -972,8 +972,13 @@ class PDSGeneratorGUI(tk.Tk):
         h = self.page_height * self.scale
         container_w = self.canvas_container.winfo_width()
         container_h = self.canvas_container.winfo_height()
-        margin_x = max(20, (container_w - w) // 2)
-        margin_y = max(20, (container_h - h) // 2)
+        # Ensure the scrollable area is always larger than the visible
+        # container so the page can be panned freely without disappearing
+        # under the gray background. When the window is larger than the
+        # page, use the container dimensions as extra margins so there is
+        # always space to drag the page in any direction.
+        margin_x = max(20, container_w)
+        margin_y = max(20, container_h)
         self.margin_x = margin_x
         self.margin_y = margin_y
         self.canvas.configure(scrollregion=(-margin_x, -margin_y, w + margin_x, h + margin_y))


### PR DESCRIPTION
## Summary
- allow dynamic canvas margins to avoid hitting scrollregion limits
- adjust centering and zooming to account for new margins

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b69ef78dec8320bd813377b57214c9