### PR TITLE
Refactor GUI into modular package

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -1,0 +1,3 @@
+from .gui import PDSGeneratorGUI
+
+__all__ = ["PDSGeneratorGUI"]

--- a/gui/config_io.py
+++ b/gui/config_io.py
@@ -1,0 +1,121 @@
+import json
+import os
+import logging
+import tkinter as tk
+from tkinter import messagebox
+
+from elements import DraggableElement
+from groups import GroupArea
+
+CONFIG_FILE = os.path.join(os.path.dirname(__file__), "config.json")
+
+logger = logging.getLogger(__name__)
+
+
+def save_config(app):
+    if not app.excel_path:
+        messagebox.showerror("Błąd", "Najpierw wybierz plik Excel")
+        return
+    config = {
+        "excel_path": app.excel_path,
+        "page_width": app.page_width,
+        "page_height": app.page_height,
+        "elements": [el.to_dict() for el in app.elements.values()],
+        "static_fields": {name: var.get() for name, var in app.static_entries.items()},
+        "conditions": app.conditions,
+        "groups": [g.to_dict() for g in app.groups.values()],
+    }
+    with open(CONFIG_FILE, "w", encoding="utf-8") as f:
+        json.dump(config, f, ensure_ascii=False, indent=2)
+    messagebox.showinfo("Zapisano", f"Zapisano konfigurację do {CONFIG_FILE}")
+
+
+def load_config(app, startup=False, path=None):
+    if not os.path.exists(CONFIG_FILE):
+        return
+    try:
+        with open(CONFIG_FILE, "r", encoding="utf-8") as f:
+            config = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        logger.exception("Failed to load config from %s", CONFIG_FILE)
+        return
+    excel_cfg = config.get("excel_path")
+    if startup and excel_cfg and os.path.exists(excel_cfg):
+        app.excel_path = excel_cfg
+        app.image_cache = {}
+        app.path_var.set(excel_cfg)
+        app.load_excel(excel_cfg)
+    if path and excel_cfg != path:
+        return
+    app.page_width = config.get("page_width", app.page_width)
+    app.page_height = config.get("page_height", app.page_height)
+    set_name = None
+    for n, sz in app.PAGE_SIZES.items():
+        if abs(sz[0] - app.page_width) < 1 and abs(sz[1] - app.page_height) < 1:
+            set_name = n
+            break
+    if set_name:
+        app.size_var.set(set_name)
+    else:
+        app.size_var.set(f"{int(app.page_width)}x{int(app.page_height)}")
+    app.resize_canvas()
+    for name, val in config.get("static_fields", {}).items():
+        if name not in app.static_vars:
+            app.create_static_row(name, val)
+        else:
+            app.static_entries[name].set(val)
+    app.conditions = config.get("conditions", [])
+    for elconf in config.get("elements", []):
+        name = elconf["name"]
+        if name not in app.elements:
+            element = DraggableElement(app, app.canvas, name, elconf.get("text", name))
+            element.x = elconf.get("x", element.x) * app.scale
+            element.y = elconf.get("y", element.y) * app.scale
+            element.width = elconf.get("width", element.width) * app.scale
+            element.height = elconf.get("height", element.height) * app.scale
+            element.font_size = elconf.get("font_size", element.font_size) * app.scale
+            element.bold = elconf.get("bold", element.bold)
+            element.text_color = elconf.get("text_color", element.text_color)
+            element.bg_color = elconf.get("bg_color", element.bg_color)
+            element.bg_visible = elconf.get("bg_visible", element.bg_visible)
+            element.align = elconf.get("align", element.align)
+            element.auto_font = elconf.get("auto_font", element.auto_font)
+            element.layer = elconf.get("layer", element.layer)
+            element.sync_canvas()
+            app.elements[name] = element
+            if name in app.columns_vars:
+                app.columns_vars[name].set(True)
+            if name in app.static_vars:
+                app.static_vars[name].set(True)
+                app.static_entries[name].set(elconf.get("text", ""))
+    for gconf in config.get("groups", []):
+        group = GroupArea(app, app.canvas, gconf.get("name", f"Group{len(app.groups)+1}"))
+        group.x = gconf.get("x", group.x) * app.scale
+        group.y = gconf.get("y", group.y) * app.scale
+        group.width = gconf.get("width", group.width) * app.scale
+        group.height = gconf.get("height", group.height) * app.scale
+        group.sync_canvas()
+        group.field_pos = {k: (v[0], v[1]) for k, v in gconf.get("field_pos", {}).items()}
+        group.field_conf = {
+            k: {
+                "width": fc.get("width", 100),
+                "height": fc.get("height", 40),
+                "font_size": fc.get("font_size", 12),
+                "bold": fc.get("bold", False),
+                "text_color": fc.get("text_color", "black"),
+                "bg_color": fc.get("bg_color", "white"),
+                "bg_visible": fc.get("bg_visible", True),
+                "align": fc.get("align", "left"),
+                "auto_font": fc.get("auto_font", True),
+                "layer": fc.get("layer", 1),
+            }
+            for k, fc in gconf.get("field_conf", {}).items()
+        }
+        group.fields = list(group.field_pos.keys())
+        group.conditions = gconf.get("conditions", [])
+        group.draw_preview()
+        app.groups[group.name] = group
+        if hasattr(app, "groups_list"):
+            app.groups_list.insert("end", group.name)
+    app.restack_elements()
+    app.push_history()

--- a/gui/pdf_export.py
+++ b/gui/pdf_export.py
@@ -1,0 +1,233 @@
+import logging
+import os
+import time
+import threading
+import re
+from io import BytesIO
+from types import SimpleNamespace
+
+import pandas as pd
+import requests
+from PIL import Image
+from reportlab.pdfgen import canvas as pdf_canvas
+from reportlab.lib.utils import ImageReader
+from reportlab.lib import colors
+import tkinter as tk
+from tkinter import messagebox
+
+logger = logging.getLogger(__name__)
+
+
+def to_reportlab_color(value):
+    try:
+        return colors.HexColor(value)
+    except (ValueError, TypeError):
+        return colors.toColor(value)
+
+
+def sanitize_filename(name: str) -> str:
+    cleaned = re.sub(r"[^\w\s-]", "", str(name))
+    cleaned = re.sub(r"\s+", "_", cleaned).strip("_")
+    return cleaned
+
+
+def draw_pdf_element(app, c, element, value, x, y):
+    if isinstance(value, str) and value.lower().startswith("http"):
+        try:
+            resp = requests.get(value, timeout=5)
+            img = Image.open(BytesIO(resp.content))
+            c.drawImage(
+                ImageReader(img),
+                x,
+                y,
+                width=element.width / app.scale,
+                height=element.height / app.scale,
+            )
+            return
+        except (requests.RequestException, OSError):
+            logger.exception("Failed to load remote image %s", value)
+    if isinstance(value, str):
+        local_path = app.find_local_image(value)
+        if local_path:
+            try:
+                img = Image.open(local_path)
+                c.drawImage(
+                    ImageReader(img),
+                    x,
+                    y,
+                    width=element.width / app.scale,
+                    height=element.height / app.scale,
+                )
+                return
+            except OSError:
+                logger.exception("Failed to load local image %s", local_path)
+    if element.bg_visible:
+        c.setFillColor(to_reportlab_color(element.bg_color))
+        c.rect(
+            x,
+            y,
+            element.width / app.scale,
+            element.height / app.scale,
+            fill=1,
+            stroke=0,
+        )
+    c.setFillColor(to_reportlab_color(element.text_color))
+    c.setFont(
+        "Helvetica-Bold" if element.bold else "Helvetica",
+        element.font_size / app.scale,
+    )
+    if element.align == "center":
+        c.drawCentredString(
+            x + (element.width / app.scale) / 2,
+            y + (element.height / app.scale) / 2,
+            str(value),
+        )
+    elif element.align == "right":
+        c.drawRightString(
+            x + (element.width / app.scale),
+            y + (element.height / app.scale) / 2,
+            str(value),
+        )
+    else:
+        c.drawString(x, y + (element.height / app.scale) / 2, str(value))
+
+
+def generate_pds(app):
+    if not app.excel_path or not app.dataframes:
+        messagebox.showerror("Błąd", "Brak danych do generowania")
+        return
+    first_df = next(iter(app.dataframes.values()))
+    total_rows = len(first_df)
+    if total_rows == 0:
+        messagebox.showinfo("Info", "Brak wierszy w pliku Excel")
+        return
+    output_dir = os.path.join(os.path.dirname(app.excel_path), "PDS")
+    os.makedirs(output_dir, exist_ok=True)
+
+    page_width = app.page_width
+    page_height = app.page_height
+
+    def worker():
+        start_time = time.time()
+        for idx in range(total_rows):
+            first_val = first_df.iloc[idx, 0] if first_df.shape[1] else ""
+            filename = sanitize_filename(first_val) or f"pds_{idx+1}"
+            pdf_path = os.path.join(output_dir, f"{filename}.pdf")
+            tmp_path = pdf_path + ".tmp"
+            c = pdf_canvas.Canvas(tmp_path, pagesize=(page_width, page_height))
+            needed = set(app.elements.keys())
+            for g in app.groups.values():
+                needed.update(g.fields)
+            needed.update(app.static_entries.keys())
+            values = {}
+            for name in needed:
+                if ":" in name:
+                    sheet, col = name.split(":", 1)
+                    df = app.dataframes.get(sheet)
+                    value = df.iloc[idx].get(col, "") if df is not None else ""
+                else:
+                    value = app.static_entries.get(name, tk.StringVar()).get()
+                if pd.isna(value):
+                    value = ""
+                values[name] = value
+            group_field_names = {fname for g in app.groups.values() for fname in g.fields}
+
+            hidden = set()
+            for src, tgt in app.conditions:
+                if src in group_field_names or tgt in group_field_names:
+                    continue
+                if pd.isna(values.get(src)) or values.get(src) == "":
+                    hidden.add(tgt)
+            for group in app.groups.values():
+                g_hidden = set()
+                for src, tgt in group.conditions:
+                    if src not in group.fields or tgt not in group.fields:
+                        continue
+                    if pd.isna(values.get(src)) or values.get(src) == "":
+                        g_hidden.add(tgt)
+                positions = group.field_pos
+                columns = {}
+                for fname in group.fields:
+                    if fname in hidden or fname in g_hidden:
+                        continue
+                    val = values.get(fname, "")
+                    if val == "":
+                        continue
+                    conf = group.field_conf.get(fname, {})
+                    el = app.elements.get(fname)
+                    if not conf and not el:
+                        continue
+                    width = conf.get("width", el.width if el else 0)
+                    height = conf.get("height", el.height if el else 0)
+                    x0, y0 = positions.get(fname, (0, 0))
+                    columns.setdefault(x0, []).append((y0, fname, width, height, conf, el, val))
+
+                placed = []
+                for x0 in sorted(columns):
+                    col_items = columns[x0]
+                    col_items.sort(key=lambda t: t[0])
+                    cur_y = 0
+                    for _, fname, width, height, conf, el, val in col_items:
+                        y = cur_y
+                        while True:
+                            overlap = False
+                            for px, py, pw, ph in placed:
+                                if (
+                                    x0 < px + pw
+                                    and x0 + width > px
+                                    and y < py + ph
+                                    and y + height > py
+                                ):
+                                    y = py + ph
+                                    overlap = True
+                                    break
+                            if not overlap:
+                                break
+                        if y + height > group.height:
+                            continue
+                        dummy = SimpleNamespace(
+                            width=width,
+                            height=height,
+                            font_size=conf.get("font_size", el.font_size if el else 12),
+                            bold=conf.get("bold", el.bold if el else False),
+                            text_color=conf.get("text_color", el.text_color if el else "black"),
+                            bg_color=conf.get("bg_color", el.bg_color if el else "white"),
+                            bg_visible=conf.get("bg_visible", el.bg_visible if el else True),
+                            align=conf.get("align", el.align if el else "left"),
+                            auto_font=conf.get("auto_font", el.auto_font if el else True),
+                        )
+                        x_pdf = (group.x + x0) / app.scale
+                        y_pdf = page_height - (group.y + y + height) / app.scale
+                        draw_pdf_element(app, c, dummy, val, x_pdf, y_pdf)
+                        placed.append((x0, y, width, height))
+                        cur_y = y + height
+            for name, element in sorted(app.elements.items(), key=lambda kv: kv[1].layer):
+                if name in hidden:
+                    continue
+                val = values.get(name, "")
+                x = element.x / app.scale
+                y = page_height - (element.y / app.scale) - (element.height / app.scale)
+                draw_pdf_element(app, c, element, val, x, y)
+            c.showPage()
+            c.save()
+            try:
+                os.replace(tmp_path, pdf_path)
+            except OSError:
+                logger.exception("Failed to replace %s, trying alternative name", pdf_path)
+                alt_path = pdf_path.replace(
+                    ".pdf", f"_{int(time.time())}.pdf"
+                )
+                try:
+                    os.replace(tmp_path, alt_path)
+                except OSError:
+                    logger.exception("Failed to move temp PDF to %s", alt_path)
+            progress = (idx + 1) / total_rows * 100
+            elapsed = time.time() - start_time
+            remaining = (elapsed / (idx + 1)) * (total_rows - idx - 1)
+            app.progress.after(0, lambda p=progress: app.progress.config(value=p))
+            app.time_label.after(0, lambda r=remaining: app.time_label.config(text=f"Pozostały czas: {int(r)} s"))
+        app.progress.after(0, lambda: app.progress.config(value=0))
+        app.time_label.after(0, lambda: app.time_label.config(text="Zakończono"))
+        messagebox.showinfo("Zakończono", f"Pliki zapisane w {output_dir}")
+
+    threading.Thread(target=worker, daemon=True).start()

--- a/gui/ui_layout.py
+++ b/gui/ui_layout.py
@@ -1,0 +1,145 @@
+import tkinter as tk
+from tkinter import ttk
+
+
+def setup_ui(app):
+    top_frame = ttk.Frame(app)
+    top_frame.pack(fill="x", padx=5, pady=5)
+
+    ttk.Label(top_frame, text="Plik Excel:").pack(side="left")
+    app.path_var = tk.StringVar()
+    app.path_entry = ttk.Entry(top_frame, textvariable=app.path_var, width=60)
+    app.path_entry.pack(side="left", padx=5)
+    ttk.Button(top_frame, text="Przeglądaj", command=app.browse_file).pack(side="left")
+
+    ttk.Label(top_frame, text="Rozmiar strony:").pack(side="left", padx=(20, 0))
+    app.size_var = tk.StringVar(value="A4")
+    app.size_entry = ttk.Entry(top_frame, textvariable=app.size_var, width=10)
+    app.size_entry.pack(side="left")
+    ttk.Button(top_frame, text="Ustaw", command=app.update_canvas_size).pack(side="left", padx=2)
+    app.size_entry.bind("<Return>", lambda e: app.update_canvas_size())
+
+    format_frame = ttk.Frame(app)
+    format_frame.pack(fill="x", padx=5)
+    ttk.Button(format_frame, text="B", command=app.toggle_bold).pack(side="left")
+    ttk.Button(format_frame, text="A+", command=app.increase_font).pack(side="left", padx=2)
+    ttk.Button(format_frame, text="A-", command=app.decrease_font).pack(side="left")
+    app.font_size_var = tk.StringVar()
+    app.font_entry = ttk.Entry(format_frame, textvariable=app.font_size_var, width=4, state="disabled")
+    app.font_entry.pack(side="left", padx=5)
+    app.font_entry.bind("<Return>", lambda e: app.set_font_size())
+    ttk.Button(format_frame, text="Kolor", command=app.choose_text_color).pack(side="left", padx=2)
+    ttk.Button(format_frame, text="Tło", command=app.choose_bg_color).pack(side="left", padx=2)
+    app.transparent_var = tk.BooleanVar(value=False)
+    app.bg_check = ttk.Checkbutton(
+        format_frame,
+        text="Przezroczyste",
+        variable=app.transparent_var,
+        command=app.toggle_bg_visible,
+    )
+    app.bg_check.pack(side="left", padx=2)
+    app.bg_check.state(["disabled"])
+    ttk.Button(format_frame, text="L", command=lambda: app.set_alignment("left")).pack(side="left", padx=2)
+    ttk.Button(format_frame, text="C", command=lambda: app.set_alignment("center")).pack(side="left", padx=2)
+    ttk.Button(format_frame, text="R", command=lambda: app.set_alignment("right")).pack(side="left", padx=2)
+    ttk.Button(format_frame, text="Środek H", command=app.center_selected_horizontal).pack(side="left", padx=2)
+    ttk.Button(format_frame, text="Środek V", command=app.center_selected_vertical).pack(side="left", padx=2)
+    ttk.Label(format_frame, text="Warstwa:").pack(side="left", padx=(5, 0))
+    app.layer_var = tk.StringVar()
+    app.layer_entry = ttk.Entry(format_frame, textvariable=app.layer_var, width=4, state="disabled")
+    app.layer_entry.pack(side="left", padx=2)
+    app.layer_entry.bind("<Return>", lambda e: app.set_layer())
+    app.canvas_container = tk.Frame(app, bg="#b0b0b0")
+    app.canvas_container.pack(side="left", fill="both", expand=True, padx=5, pady=5)
+    app.canvas_container.pack_propagate(False)
+    app.canvas_container.bind("<Configure>", app.resize_canvas)
+    app.canvas = tk.Canvas(
+        app.canvas_container,
+        bg="#b0b0b0",
+        highlightthickness=0,
+    )
+    app.canvas.pack(fill="both", expand=True)
+    app.canvas.bind("<ButtonPress-1>", app.canvas_button_press)
+    app.canvas.bind("<B1-Motion>", app.canvas_drag_select)
+    app.canvas.bind("<ButtonRelease-1>", app.canvas_button_release)
+    app.canvas.bind("<Control-MouseWheel>", app.ctrl_zoom)
+    app.canvas.bind("<Control-Button-4>", lambda e: app.ctrl_zoom(e, 120))
+    app.canvas.bind("<Control-Button-5>", lambda e: app.ctrl_zoom(e, -120))
+    app.canvas.bind("<ButtonPress-2>", app.start_pan)
+    app.canvas.bind("<B2-Motion>", app.pan_canvas)
+    app.canvas.configure(scrollregion=(-app.margin, -app.margin, app.page_width + app.margin, app.page_height + app.margin))
+
+    zoom_frame = ttk.Frame(app.canvas_container)
+    zoom_frame.place(relx=1.0, rely=1.0, anchor="se", x=-5, y=-5)
+    ttk.Button(zoom_frame, text="Dopasuj", command=app.fit_to_window).pack(side="right")
+    app.zoom_var = tk.StringVar(value="100%")
+    ttk.Label(zoom_frame, textvariable=app.zoom_var).pack(side="right", padx=5)
+
+    right_container = ttk.Frame(app)
+    right_container.pack(side="right", fill="y", padx=5, pady=5)
+    app.right_canvas = tk.Canvas(right_container, width=300)
+    right_scroll = ttk.Scrollbar(right_container, orient="vertical", command=app.right_canvas.yview)
+    app.right_canvas.configure(yscrollcommand=right_scroll.set)
+    right_scroll.pack(side="right", fill="y")
+    app.right_canvas.pack(side="left", fill="both", expand=True)
+    right_frame = ttk.Frame(app.right_canvas)
+    app.right_canvas.create_window((0,0), window=right_frame, anchor="nw")
+    right_frame.bind("<Configure>", lambda e: app.right_canvas.configure(scrollregion=app.right_canvas.bbox("all")))
+    app.right_canvas.bind("<Enter>", lambda e: app.right_canvas.bind_all("<MouseWheel>", app._on_mousewheel))
+    app.right_canvas.bind("<Leave>", lambda e: app.right_canvas.unbind_all("<MouseWheel>"))
+    app.right_canvas.bind("<Button-4>", lambda e: app.right_canvas.yview_scroll(-1, "units"))
+    app.right_canvas.bind("<Button-5>", lambda e: app.right_canvas.yview_scroll(1, "units"))
+
+    # Dynamic column checkboxes
+    ttk.Label(right_frame, text="Kolumny z Excela:").pack(anchor="w")
+    app.columns_frame = ttk.Frame(right_frame)
+    app.columns_frame.pack(fill="y", expand=True)
+    app.columns_vars = {}
+
+    # Static field checkboxes
+    ttk.Label(right_frame, text="Pola statyczne:").pack(anchor="w", pady=(10, 0))
+    app.static_frame = ttk.Frame(right_frame)
+    app.static_frame.pack(fill="x")
+    app.static_vars = {}
+    app.static_entries = {}
+    app.static_rows = {}
+    for field in app.DEFAULT_STATIC_FIELDS:
+        app.create_static_row(field, "")
+    app.add_static_btn = ttk.Button(app.static_frame, text="Dodaj pole", command=app.add_static_field)
+    app.add_static_btn.pack(fill="x", pady=5)
+
+    # Row preview controls
+    preview_frame = ttk.Frame(right_frame)
+    preview_frame.pack(fill="x", pady=(10, 0))
+    ttk.Label(preview_frame, text="Numer wiersza:").pack(side="left")
+    app.row_var = tk.StringVar(value="1")
+    ttk.Entry(preview_frame, textvariable=app.row_var, width=6).pack(side="left")
+    ttk.Button(preview_frame, text="Podgląd", command=app.preview_row).pack(side="left", padx=5)
+
+    # Group list
+    ttk.Label(right_frame, text="Grupy:").pack(anchor="w", pady=(10, 0))
+    grp_container = ttk.Frame(right_frame)
+    grp_container.pack(fill="x")
+    app.groups_list = tk.Listbox(grp_container, height=5)
+    app.groups_list.pack(side="left", fill="both", expand=True)
+    grp_scroll = ttk.Scrollbar(grp_container, orient="vertical", command=app.groups_list.yview)
+    grp_scroll.pack(side="right", fill="y")
+    app.groups_list.configure(yscrollcommand=grp_scroll.set)
+    app.groups_list.bind("<Double-1>", lambda e: app.edit_selected_group())
+    ttk.Button(right_frame, text="Usuń grupę", command=app.remove_group).pack(fill="x", pady=(5, 0))
+
+    # Buttons
+    button_frame = ttk.Frame(right_frame)
+    button_frame.pack(fill="x", pady=(20, 0))
+    ttk.Button(button_frame, text="Zapisz konfigurację", command=app.save_config).pack(fill="x")
+    ttk.Button(button_frame, text="Warunki", command=app.open_conditions).pack(fill="x", pady=5)
+    ttk.Button(button_frame, text="Dodaj grupę", command=app.add_group).pack(fill="x", pady=5)
+    ttk.Button(button_frame, text="Generuj PDS", command=app.generate_pds).pack(fill="x", pady=5)
+
+    # Progress bar
+    app.progress = ttk.Progressbar(right_frame, orient="horizontal", mode="determinate")
+    app.progress.pack(fill="x", pady=(20, 0))
+    app.time_label = ttk.Label(right_frame, text="")
+    app.time_label.pack()
+    app.draw_grid()
+    app.bind_all("<Delete>", app.delete_selected)


### PR DESCRIPTION
## Summary
- Split monolithic GUI code into a new `gui` package with dedicated modules for layout, PDF export and configuration handling
- Updated `PDSGeneratorGUI` to delegate widget creation, PDF generation and config persistence to the new modules

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b6af61afc88320a187b6a6ff089b5a