### PR TITLE
Improve GitHub update handling

### DIFF
--- a/github_utils.py
+++ b/github_utils.py
@@ -1,12 +1,30 @@
-"""Utility helpers for GitHub update checks and repository updates."""
+"""Utility helpers for GitHub update checks and repository updates.
+
+These helpers are intentionally defensive so that the application can still
+check for new versions when it is distributed as plain files without a Git
+clone.  In such a scenario there is no local ``.git`` directory and the
+repository information cannot be derived from ``git`` commands.  We therefore
+fall back to the public GitHub repository defined below.
+"""
+
+import io
 import logging
 import os
+import shutil
 import subprocess
+import zipfile
 from typing import Optional, Tuple
 
 import requests
 
 logger = logging.getLogger(__name__)
+
+# Default repository details used when the local copy does not contain git
+# metadata (for example when the application was distributed as plain files).
+# They point to the public GitHub repository of the project.
+DEFAULT_OWNER = "NefilimPL"
+DEFAULT_REPO = "PDS-Generator_from_excel"
+DEFAULT_BRANCH = "MAIN"
 
 
 def get_repo_info(repo_dir: str) -> Tuple[Optional[str], Optional[str], Optional[str]]:
@@ -23,6 +41,7 @@ def get_repo_info(repo_dir: str) -> Tuple[Optional[str], Optional[str], Optional
         ).decode().strip()
     except Exception as err:  # pragma: no cover - best effort logging
         logger.debug("Failed to get local git hash: %s", err)
+
     try:
         remote_url = subprocess.check_output(
             ["git", "config", "--get", "remote.origin.url"], cwd=repo_dir
@@ -38,6 +57,10 @@ def get_repo_info(repo_dir: str) -> Tuple[Optional[str], Optional[str], Optional
                 owner, repo = owner_repo.split("/", 1)
     except Exception as err:  # pragma: no cover - best effort logging
         logger.debug("Failed to get remote URL: %s", err)
+
+    # Fallback to defaults when repository information cannot be determined.
+    owner = owner or DEFAULT_OWNER
+    repo = repo or DEFAULT_REPO
     return local_hash, owner, repo
 
 
@@ -55,17 +78,62 @@ def get_remote_hash(owner: str, repo: str, branch: str = "MAIN") -> Optional[str
     return None
 
 
-def pull_updates(repo_dir: str) -> bool:
-    """Attempt to update the repository using ``git pull``.
-
-    Returns ``True`` if the pull succeeded, ``False`` otherwise.
-    """
+def get_remote_version(owner: str, repo: str, branch: str = DEFAULT_BRANCH) -> Optional[str]:
+    """Return the ``VERSION`` file value from the remote repository."""
     try:
+        url = f"https://raw.githubusercontent.com/{owner}/{repo}/{branch}/VERSION"
+        resp = requests.get(url, timeout=5)
+        resp.raise_for_status()
+        return resp.text.strip()
+    except Exception as err:  # pragma: no cover - best effort logging
+        logger.debug("Failed to fetch remote VERSION: %s", err)
+    return None
+
+
+def _download_and_extract(repo_dir: str, owner: str, repo: str, branch: str) -> bool:
+    """Download repo archive from GitHub and extract into ``repo_dir``."""
+    url = f"https://codeload.github.com/{owner}/{repo}/zip/refs/heads/{branch}"
+    try:
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+        with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+            top = f"{repo}-{branch}"
+            for member in zf.namelist():
+                if not member.startswith(top + "/"):
+                    continue
+                rel_path = member[len(top) + 1 :]
+                if not rel_path:
+                    continue
+                target = os.path.join(repo_dir, rel_path)
+                if member.endswith("/"):
+                    os.makedirs(target, exist_ok=True)
+                else:
+                    os.makedirs(os.path.dirname(target), exist_ok=True)
+                    with zf.open(member) as src, open(target, "wb") as dst:
+                        shutil.copyfileobj(src, dst)
+        return True
+    except Exception as err:  # pragma: no cover - best effort logging
+        logger.error("Failed to download archive: %s", err)
+    return False
+
+
+def pull_updates(repo_dir: str, branch: str = DEFAULT_BRANCH) -> bool:
+    """Attempt to update the repository.
+
+    Tries ``git pull`` first. If that fails it falls back to downloading the
+    repository archive from GitHub and extracting it over existing files. This
+    also restores any files that might be missing locally.
+    """
+
+    try:
+        subprocess.run(["git", "fetch"], cwd=repo_dir, check=True)
         subprocess.run(["git", "pull"], cwd=repo_dir, check=True)
         return True
     except Exception as err:  # pragma: no cover - best effort logging
         logger.error("Failed to pull updates: %s", err)
-    return False
+
+    _, owner, repo = get_repo_info(repo_dir)
+    return _download_and_extract(repo_dir, owner, repo, branch)
 
 
 def get_last_update_date(repo_dir: str) -> Optional[str]:

--- a/gui/gui.py
+++ b/gui/gui.py
@@ -25,6 +25,7 @@ from .config_io import (
 from github_utils import (
     get_repo_info,
     get_remote_hash,
+    get_remote_version,
     pull_updates,
     get_last_update_date,
     get_version,
@@ -102,10 +103,14 @@ class PDSGeneratorGUI(tk.Tk):
     def check_for_updates(self):
         local_hash, owner, repo = get_repo_info(self.repo_dir)
         self.repo_owner, self.repo_name = owner, repo
-        remote_hash = get_remote_hash(owner, repo) if owner and repo else None
-        self.update_available = (
-            remote_hash and local_hash and remote_hash != local_hash
-        )
+
+        remote_hash = get_remote_hash(owner, repo) if local_hash else None
+        if local_hash and remote_hash:
+            self.update_available = remote_hash != local_hash
+        else:
+            remote_version = get_remote_version(owner, repo)
+            self.update_available = bool(remote_version and remote_version != self.version)
+
         if self.update_available:
             self.update_button.pack(side="left", padx=5)
             self.blink_update_button()


### PR DESCRIPTION
## Summary
- fallback to default GitHub repo when local git metadata is missing
- support remote version checks and zip-based update downloads
- show update button and GitHub link even for copied file bundles

## Testing
- `python -m py_compile github_utils.py gui/gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6cd3bc83c8320a4ad019ef34297fe