### PR TITLE
Handle path type conflicts during update extraction

### DIFF
--- a/github_utils.py
+++ b/github_utils.py
@@ -106,8 +106,15 @@ def _download_and_extract(repo_dir: str, owner: str, repo: str, branch: str) -> 
                     continue
                 target = os.path.join(repo_dir, rel_path)
                 if member.endswith("/"):
+                    if os.path.isfile(target) or os.path.islink(target):
+                        os.remove(target)
                     os.makedirs(target, exist_ok=True)
                 else:
+                    if os.path.exists(target):
+                        if os.path.isdir(target) and not os.path.islink(target):
+                            shutil.rmtree(target)
+                        else:
+                            os.remove(target)
                     os.makedirs(os.path.dirname(target), exist_ok=True)
                     with zf.open(member) as src, open(target, "wb") as dst:
                         shutil.copyfileobj(src, dst)


### PR DESCRIPTION
## Summary
- Remove existing files or directories when a ZIP entry changes type
- Ensure fallback updater can overlay files that switch between directories and regular files

## Testing
- `python -m py_compile github_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6d0b1070c8320a91ee90b0fe55f10