### PR TITLE
Fix Windows launcher by installing full Python runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,44 @@ Prosty generator PDS (PDF) na podstawie danych z Excela z opcją dodawania nowyc
 
 ## Uruchomienie
 
+Jeśli nie masz zainstalowanego środowiska Python, możesz skorzystać ze
+skryptu `launcher.py`, który w razie potrzeby pobierze i zainstaluje
+lokalną kopię Pythona (na systemie Windows) i uruchomi główną aplikację.
+Przy pierwszym uruchomieniu pojawi się niewielkie okno pokazujące postęp
+pobierania i instalacji. Przy kolejnych uruchomieniach wykorzystana
+zostanie już pobrana wersja.
+Na Windowsie launcher uruchamia `pythonw.exe`, dzięki czemu przy starcie
+nie pojawia się dodatkowa konsola:
+
+```bash
+python launcher.py
+```
+
+Gdy Python jest już zainstalowany, program można uruchomić bezpośrednio:
+
 ```bash
 python pds_gui.py
 ```
+
+### Budowanie samodzielnego `launcher.exe`
+
+W repozytorium znajduje się skrypt `build_launcher_exe.bat`, który tworzy
+samodzielny plik wykonywalny `launcher.exe`. Skrypt nie wymaga wcześniej
+zainstalowanego Pythona – w razie potrzeby pobiera oficjalny instalator,
+instaluje Pythona do katalogu `python_runtime` (bez tworzenia skrótów),
+po czym instaluje PyInstaller i pakuje `launcher.py` w pojedynczy plik EXE.
+Jeżeli katalog `python_runtime` już istnieje, skrypt wykorzysta
+zainstalowany tam interpreter, dzięki czemu ponowne budowanie jest
+znacznie szybsze.
+
+```bash
+build_launcher_exe.bat
+```
+
+Po zakończeniu w katalogu projektu pojawi się plik `launcher.exe` oraz
+zainstalowany interpreter w podkatalogu `python_runtime`. Dzięki temu
+`launcher.exe` może uruchomić aplikację bez dodatkowego pobierania
+Pythona.
 
 Po uruchomieniu aplikacji:
 

--- a/build_launcher_exe.bat
+++ b/build_launcher_exe.bat
@@ -1,0 +1,38 @@
+@echo off
+setlocal
+
+set TEMP_DIR=%~dp0build_env
+set PY_DIR=%~dp0python_runtime
+set PY_VERSION=3.11.6
+set PY_URL=https://www.python.org/ftp/python/%PY_VERSION%/python-%PY_VERSION%-amd64.exe
+
+if not exist "%PY_DIR%\python.exe" (
+    if exist "%TEMP_DIR%" rmdir /S /Q "%TEMP_DIR%"
+    mkdir "%TEMP_DIR%"
+    echo Downloading Python installer...
+    powershell -Command "Invoke-WebRequest '%PY_URL%' -OutFile '%TEMP_DIR%\python-installer.exe'"
+    echo Installing Python into %PY_DIR%...
+    "%TEMP_DIR%\python-installer.exe" /quiet InstallAllUsers=0 Include_pip=1 Include_tcltk=1 PrependPath=0 Shortcuts=0 TargetDir="%PY_DIR%" >nul
+) else (
+    echo Using existing Python in %PY_DIR%...
+)
+
+echo Installing PyInstaller...
+"%PY_DIR%\python.exe" -m pip install --upgrade pip pyinstaller >nul
+
+echo Building launcher.exe...
+"%PY_DIR%\python.exe" -m PyInstaller launcher.py --onefile --noconsole --name launcher
+
+if exist dist\launcher.exe (
+    copy dist\launcher.exe launcher.exe >nul
+    echo launcher.exe created.
+) else (
+    echo Build failed.
+)
+
+echo Cleaning up...
+rmdir /S /Q "%TEMP_DIR%" >nul 2>&1
+rmdir /S /Q build dist __pycache__ >nul 2>&1
+del launcher.spec >nul 2>&1
+echo Done.
+

--- a/launcher.py
+++ b/launcher.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Simple launcher for PDS generator.
+
+On Windows it downloads and installs a private Python runtime (including
+``pip`` and ``tkinter``) and uses it to run ``pds_gui.py``. On other platforms
+the system Python is used directly.
+"""
+from __future__ import annotations
+
+import platform
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+import tkinter as tk
+from tkinter import ttk
+
+PYTHON_VERSION = "3.11.6"
+BASE_URL = f"https://www.python.org/ftp/python/{PYTHON_VERSION}/"
+# Place the downloaded Python runtime next to the executable/launcher script.
+BASE_DIR = Path(sys.argv[0]).resolve().parent
+PYTHON_DIR = BASE_DIR / "python_runtime"
+
+
+def _ensure_windows_python() -> Path:
+    """Download and install Python for Windows if necessary and return its path."""
+    python_exe = PYTHON_DIR / "python.exe"
+    if python_exe.exists():
+        return python_exe
+    PYTHON_DIR.mkdir(exist_ok=True)
+    installer = PYTHON_DIR / "python-installer.exe"
+    url = BASE_URL + f"python-{PYTHON_VERSION}-amd64.exe"
+
+    root = tk.Tk()
+    root.title("PDS Generator")
+    label = ttk.Label(root, text=f"Pobieranie Pythona {PYTHON_VERSION}...")
+    label.pack(padx=20, pady=(20, 10))
+    progress = ttk.Progressbar(root, length=300)
+    progress.pack(padx=20, pady=(0, 20))
+    root.update()
+
+    def reporthook(blocknum: int, blocksize: int, totalsize: int) -> None:
+        if totalsize > 0:
+            percent = blocknum * blocksize * 100 // totalsize
+            progress["value"] = percent
+            root.update()
+
+    urllib.request.urlretrieve(url, installer, reporthook)
+
+    label.config(text="Instalowanie Pythona...")
+    progress.config(mode="indeterminate")
+    progress.start(10)
+    root.update()
+
+    subprocess.run(
+        [
+            str(installer),
+            "/quiet",
+            "InstallAllUsers=0",
+            "Include_pip=1",
+            "Include_tcltk=1",
+            "PrependPath=0",
+            f"TargetDir={PYTHON_DIR}",
+        ],
+        check=True,
+    )
+    progress.stop()
+    root.destroy()
+    # Wait for python.exe to appear as some installer operations are asynchronous.
+    for _ in range(30):
+        if python_exe.exists():
+            break
+        time.sleep(1)
+    else:
+        raise RuntimeError("Nie można odnaleźć python.exe po instalacji")
+    installer.unlink(missing_ok=True)
+    return python_exe
+
+
+def main() -> None:
+    system = platform.system()
+    if system == "Windows":
+        python = _ensure_windows_python()
+        # Use pythonw.exe to avoid showing a console window when launching the GUI
+        pythonw = python.with_name("pythonw.exe")
+        if pythonw.exists():
+            python = pythonw
+    else:
+        python = Path(sys.executable)
+    script = BASE_DIR / "pds_gui.py"
+    # Run from the repository directory so update checks and relative paths work.
+    subprocess.run([str(python), str(script)], check=True, cwd=BASE_DIR)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- hide the console when starting the GUI by preferring `pythonw.exe`
- run the app from the repo directory to keep update detection working
- allow `build_launcher_exe.bat` to reuse an existing `python_runtime` instead of reinstalling Python
- display a progress window when downloading and installing Python on first launch

## Testing
- `python -m pytest >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b8021a50388320948727193979b4a4