### PR TITLE
Prefer Excel-local config with locking

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ PDF – dla każdego wiersza arkusza powstaje oddzielny dokument.
 - Obsługa obrazów lokalnych lub zdalnych (URL podany w komórce Excela).
 - Grupowanie pól w *obszary* z własnym podglądem i indywidualną konfiguracją,
   w tym warunkowym ukrywaniem elementów zależnie od zawartości innych pól.
-- Zapisywanie i wczytywanie konfiguracji do pliku
-  `~/.pds_generator/config.json` – zapamiętywane są m.in. rozmieszczenie
+- Zapisywanie i wczytywanie konfiguracji do pliku `config.json` w katalogu
+  wybranego pliku Excel (tworzona jest także kopia zapasowa w
+  `~/.pds_generator/config.json`) – zapamiętywane są m.in. rozmieszczenie
   elementów, ostatnio użyty plik Excel, pola statyczne czy grupy.
 - Automatyczne sprawdzanie dostępności nowszej wersji programu w repozytorium
   GitHub oraz możliwość pobrania aktualizacji.

--- a/pds_generator/gui/config_io.py
+++ b/pds_generator/gui/config_io.py
@@ -20,6 +20,35 @@ def _ensure_config_dir():
     os.makedirs(CONFIG_DIR, exist_ok=True)
 
 
+def _excel_config_path(excel_path):
+    if not excel_path:
+        return None
+    return os.path.join(os.path.dirname(excel_path), "config.json")
+
+
+def _acquire_lock(path):
+    lock = f"{path}.lock"
+    if os.path.exists(lock):
+        messagebox.showerror("Błąd", f"Plik {os.path.basename(path)} jest używany na innym komputerze")
+        return None
+    try:
+        with open(lock, "w", encoding="utf-8") as f:
+            f.write(str(os.getpid()))
+    except OSError:
+        logger.exception("Failed to create lock %s", lock)
+        messagebox.showerror("Błąd", f"Nie można utworzyć blokady dla {path}")
+        return None
+    return lock
+
+
+def _release_lock(path):
+    if path and os.path.exists(path):
+        try:
+            os.remove(path)
+        except OSError:
+            logger.exception("Failed to remove lock %s", path)
+
+
 def save_config(app):
     if not app.excel_path:
         messagebox.showerror("Błąd", "Najpierw wybierz plik Excel")
@@ -35,24 +64,71 @@ def save_config(app):
         "ignore_updates": getattr(app, "ignore_updates", False),
         "update_test": getattr(app, "update_test", False),
     }
+    cfg_path = _excel_config_path(app.excel_path)
+    if not cfg_path:
+        messagebox.showerror("Błąd", "Brak ścieżki do konfiguracji")
+        return
+    lock = _acquire_lock(cfg_path)
+    if not lock:
+        return
+    try:
+        with open(cfg_path, "w", encoding="utf-8") as f:
+            json.dump(config, f, ensure_ascii=False, indent=2)
+    except OSError:
+        logger.exception("Failed to save config to %s", cfg_path)
+        messagebox.showerror("Błąd", f"Nie można zapisać konfiguracji do {cfg_path}")
+    finally:
+        _release_lock(lock)
     _ensure_config_dir()
-    with open(CONFIG_FILE, "w", encoding="utf-8") as f:
-        json.dump(config, f, ensure_ascii=False, indent=2)
-    messagebox.showinfo("Zapisano", f"Zapisano konfigurację do {CONFIG_FILE}")
+    try:
+        with open(CONFIG_FILE, "w", encoding="utf-8") as f:
+            json.dump(config, f, ensure_ascii=False, indent=2)
+    except OSError:
+        logger.exception("Failed to save backup config to %s", CONFIG_FILE)
+    messagebox.showinfo("Zapisano", f"Zapisano konfigurację do {cfg_path}")
 
 
 def load_config(app, startup=False, path=None):
-    cfg_path = CONFIG_FILE
-    if not os.path.exists(cfg_path) and os.path.exists(OLD_CONFIG_FILE):
+    excel_path = path or app.excel_path
+    if not excel_path and startup and os.path.exists(CONFIG_FILE):
+        try:
+            with open(CONFIG_FILE, "r", encoding="utf-8") as f:
+                excel_path = json.load(f).get("excel_path")
+        except Exception:
+            excel_path = None
+
+    cfg_path = None
+    loaded_from_backup = False
+    if excel_path:
+        candidate = _excel_config_path(excel_path)
+        if candidate and os.path.exists(candidate):
+            cfg_path = candidate
+        else:
+            loaded_from_backup = True
+    if cfg_path is None:
+        cfg_path = CONFIG_FILE if os.path.exists(CONFIG_FILE) else None
+    if cfg_path is None and os.path.exists(OLD_CONFIG_FILE):
         cfg_path = OLD_CONFIG_FILE
-    if not os.path.exists(cfg_path):
+    if cfg_path is None or not os.path.exists(cfg_path):
         return
+
+    if getattr(app, "config_lock_path", None):
+        _release_lock(app.config_lock_path)
+        app.config_lock_path = None
+    lock = _acquire_lock(cfg_path)
+    if not lock:
+        return
+    app.config_lock_path = lock
+
     try:
         with open(cfg_path, "r", encoding="utf-8") as f:
             config = json.load(f)
     except (OSError, json.JSONDecodeError):
         logger.exception("Failed to load config from %s", cfg_path)
+        _release_lock(lock)
+        app.config_lock_path = None
         return
+
     if cfg_path == OLD_CONFIG_FILE:
         try:
             _ensure_config_dir()
@@ -60,16 +136,32 @@ def load_config(app, startup=False, path=None):
             cfg_path = CONFIG_FILE
         except OSError:
             logger.exception("Failed to migrate config to %s", CONFIG_FILE)
+    if cfg_path != CONFIG_FILE:
+        _ensure_config_dir()
+        try:
+            shutil.copy(cfg_path, CONFIG_FILE)
+        except OSError:
+            logger.exception("Failed to update backup config from %s", cfg_path)
+
     app.ignore_updates = config.get("ignore_updates", False)
     app.update_test = config.get("update_test", False)
     excel_cfg = config.get("excel_path")
     if startup and excel_cfg and os.path.exists(excel_cfg):
+        if not getattr(app, "excel_lock_path", None):
+            if not app.acquire_excel_lock(excel_cfg):
+                return
         app.excel_path = excel_cfg
         app.image_cache = {}
         app.path_var.set(excel_cfg)
         app.load_excel(excel_cfg)
-    if path and excel_cfg != path:
+    if path and excel_cfg and excel_cfg != path:
         return
+    if loaded_from_backup:
+        messagebox.showwarning(
+            "Kopia zapasowa",
+            "Otworzono konfigurację z kopii zapasowej. Prosimy o zapisanie konfiguracji.",
+        )
+
     app.page_width = config.get("page_width", app.page_width)
     app.page_height = config.get("page_height", app.page_height)
     set_name = None


### PR DESCRIPTION
## Summary
- Save GUI configuration next to the chosen Excel file while keeping a backup in the user directory
- Warn and prevent concurrent edits via simple lock files for Excel and config
- Show message when loading configuration from backup

## Testing
- `python -m pytest`
- `python -m py_compile pds_generator/gui/config_io.py pds_generator/gui/gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68bad2fc48608320b8c97c8386700ae4