### PR TITLE
Make conditions dialog resizable OLD

### DIFF
--- a/pds_generator/groups.py
+++ b/pds_generator/groups.py
@@ -671,15 +671,25 @@ class GroupEditor(tk.Toplevel):
     def open_conditions(self):
         win = tk.Toplevel(self)
         win.title("Warunki")
+
+        # make the window resizable
+        win.columnconfigure(0, weight=1)
+        win.columnconfigure(1, weight=1)
+        win.rowconfigure(2, weight=1)
+
         src_var = tk.StringVar()
         tgt_var = tk.StringVar()
         options = list(self.elements.keys())
-        ttk.Label(win, text="Jeśli puste:").grid(row=0, column=0)
-        ttk.Combobox(win, values=options, textvariable=src_var, width=20).grid(row=0, column=1)
-        ttk.Label(win, text="Ukryj:").grid(row=1, column=0)
-        ttk.Combobox(win, values=options, textvariable=tgt_var, width=20).grid(row=1, column=1)
+        ttk.Label(win, text="Jeśli puste:").grid(row=0, column=0, sticky="w")
+        ttk.Combobox(win, values=options, textvariable=src_var).grid(
+            row=0, column=1, sticky="ew", padx=5, pady=2
+        )
+        ttk.Label(win, text="Ukryj:").grid(row=1, column=0, sticky="w")
+        ttk.Combobox(win, values=options, textvariable=tgt_var).grid(
+            row=1, column=1, sticky="ew", padx=5, pady=2
+        )
         box = tk.Listbox(win, height=6)
-        box.grid(row=2, column=0, columnspan=2, sticky="nsew")
+        box.grid(row=2, column=0, columnspan=2, sticky="nsew", pady=5)
         for s, t in self.conditions:
             box.insert("end", f"{s} -> {t}")
         def add():
@@ -694,8 +704,8 @@ class GroupEditor(tk.Toplevel):
                 idx = sel[0]
                 self.conditions.pop(idx)
                 box.delete(idx)
-        ttk.Button(win, text="Dodaj", command=add).grid(row=3, column=0, sticky="ew")
-        ttk.Button(win, text="Usuń", command=remove).grid(row=3, column=1, sticky="ew")
+        ttk.Button(win, text="Dodaj", command=add).grid(row=3, column=0, sticky="ew", pady=2)
+        ttk.Button(win, text="Usuń", command=remove).grid(row=3, column=1, sticky="ew", pady=2)
 
     def push_history(self):
         """Delegate history recording to the main window."""

--- a/pds_generator/gui/gui.py
+++ b/pds_generator/gui/gui.py
@@ -561,15 +561,27 @@ class PDSGeneratorGUI(tk.Tk):
     def open_conditions(self):
         win = tk.Toplevel(self)
         win.title("Warunki")
+
+        # allow the window to expand with resizing
+        win.columnconfigure(0, weight=1)
+        win.columnconfigure(1, weight=1)
+        win.rowconfigure(3, weight=1)
+
         src_var = tk.StringVar()
         tgt_var = tk.StringVar()
         options = list(self.elements.keys())
-        ttk.Label(win, text="Jeśli puste:").grid(row=0, column=0)
-        ttk.Combobox(win, values=options, textvariable=src_var, width=20).grid(row=0, column=1)
-        ttk.Label(win, text="ukryj:").grid(row=1, column=0)
-        ttk.Combobox(win, values=options, textvariable=tgt_var, width=20).grid(row=1, column=1)
-        listbox = tk.Listbox(win, width=40)
-        listbox.grid(row=3, column=0, columnspan=2, pady=5)
+
+        ttk.Label(win, text="Jeśli puste:").grid(row=0, column=0, sticky="w")
+        ttk.Combobox(win, values=options, textvariable=src_var).grid(
+            row=0, column=1, sticky="ew", padx=5, pady=2
+        )
+        ttk.Label(win, text="ukryj:").grid(row=1, column=0, sticky="w")
+        ttk.Combobox(win, values=options, textvariable=tgt_var).grid(
+            row=1, column=1, sticky="ew", padx=5, pady=2
+        )
+
+        listbox = tk.Listbox(win)
+        listbox.grid(row=3, column=0, columnspan=2, pady=5, sticky="nsew")
         for s, t in self.conditions:
             listbox.insert("end", f"{t} jeśli {s} puste")
         def add():
@@ -578,14 +590,18 @@ class PDSGeneratorGUI(tk.Tk):
             if s and t and (s, t) not in self.conditions:
                 self.conditions.append((s, t))
                 listbox.insert("end", f"{t} jeśli {s} puste")
-        ttk.Button(win, text="Dodaj", command=add).grid(row=2, column=0, columnspan=2, pady=5)
+        ttk.Button(win, text="Dodaj", command=add).grid(
+            row=2, column=0, columnspan=2, pady=5, sticky="ew"
+        )
         def remove():
             sel = listbox.curselection()
             if sel:
                 idx = sel[0]
                 listbox.delete(idx)
                 self.conditions.pop(idx)
-        ttk.Button(win, text="Usuń zaznaczone", command=remove).grid(row=4, column=0, columnspan=2, pady=5)
+        ttk.Button(win, text="Usuń zaznaczone", command=remove).grid(
+            row=4, column=0, columnspan=2, pady=5, sticky="ew"
+        )
 
     def element_in_group(self, el, group):
         return (


### PR DESCRIPTION
## Summary
- Allow resizing of the global conditions dialog so widgets expand with the window
- Apply the same resizable grid layout to the group editor's conditions dialog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c81b3302d48320b35604e489677ebd