### PR TITLE
Handle updates outside git repos and release locks during update

### DIFF
--- a/pds_generator/github_utils.py
+++ b/pds_generator/github_utils.py
@@ -153,14 +153,35 @@ def pull_updates(repo_dir: str, branch: str = DEFAULT_BRANCH) -> bool:
     also restores any files that might be missing locally.
     """
 
+    git_dir = os.path.join(repo_dir, ".git")
+    if not os.path.isdir(git_dir):
+        logger.info(
+            "Local copy at %s is not a git repository; downloading archive from GitHub.",
+            repo_dir,
+        )
+        _, owner, repo = get_repo_info(repo_dir)
+        return _download_and_extract(repo_dir, owner, repo, branch)
+
+    git_kwargs = {
+        "cwd": repo_dir,
+        "check": True,
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "text": True,
+    }
+
     try:
-        subprocess.run(["git", "fetch"], cwd=repo_dir, check=True)
-        subprocess.run(["git", "pull"], cwd=repo_dir, check=True)
+        subprocess.run(["git", "fetch"], **git_kwargs)
+        subprocess.run(["git", "pull"], **git_kwargs)
         return True
+    except subprocess.CalledProcessError as err:  # pragma: no cover - best effort logging
+        message = err.stderr.strip() or err.stdout.strip() or str(err)
+        logger.error("Failed to pull updates via git: %s", message)
     except Exception as err:  # pragma: no cover - best effort logging
-        logger.error("Failed to pull updates: %s", err)
+        logger.error("Failed to pull updates via git: %s", err)
 
     _, owner, repo = get_repo_info(repo_dir)
+    logger.info("Falling back to downloading archive from GitHub.")
     return _download_and_extract(repo_dir, owner, repo, branch)
 
 

--- a/pds_generator/gui/gui.py
+++ b/pds_generator/gui/gui.py
@@ -173,13 +173,7 @@ class PDSGeneratorGUI(tk.Tk):
                         "Aktualizacja", "Symulacja pobierania aktualizacji."
                     )
                     return
-                if not pull_updates(self.repo_dir):
-                    messagebox.showerror(
-                        "Błąd", "Aktualizacja nie powiodła się"
-                    )
-                    return
-                python = sys.executable
-                os.execl(python, python, *sys.argv)
+                self._run_update()
 
             ttk.Button(btns, text="Aktualizuj", command=do_update).pack(
                 side="left", padx=5
@@ -194,11 +188,56 @@ class PDSGeneratorGUI(tk.Tk):
                 "Aktualizacja", "Symulacja pobierania aktualizacji."
             )
             return
-        if not pull_updates(self.repo_dir):
+        self._run_update()
+
+    def _run_update(self):
+        previous_excel_lock = self.excel_lock_path
+        previous_config_lock = self.config_lock_path
+
+        self.release_lock("excel_lock_path")
+        self.release_lock("config_lock_path")
+
+        try:
+            updated = pull_updates(self.repo_dir)
+        except Exception:  # pragma: no cover - defensive logging
+            logger.exception("Unexpected error while pulling updates")
+            updated = False
+
+        if not updated:
             messagebox.showerror("Błąd", "Aktualizacja nie powiodła się")
+            self._restore_locks_after_failed_update(
+                previous_excel_lock, previous_config_lock
+            )
             return
+
         python = sys.executable
         os.execl(python, python, *sys.argv)
+
+    def _restore_locks_after_failed_update(
+        self, excel_lock_path, config_lock_path
+    ):
+        if excel_lock_path and self.excel_path:
+            if not self.acquire_excel_lock(self.excel_path):
+                logger.warning(
+                    "Failed to reacquire Excel lock for %s", self.excel_path
+                )
+
+        if config_lock_path:
+            resource_path = (
+                config_lock_path[:-5]
+                if str(config_lock_path).endswith(".lock")
+                else None
+            )
+            if resource_path:
+                lock = locks.acquire_lock(
+                    resource_path, os.path.basename(resource_path)
+                )
+                if lock:
+                    self.config_lock_path = lock
+                else:
+                    logger.warning(
+                        "Failed to reacquire config lock for %s", resource_path
+                    )
 
     def open_github(self):
         if self.repo_owner and self.repo_name:


### PR DESCRIPTION
## Summary
- skip git operations when the local copy lacks a .git directory and log the archive fallback path
- silence git command output and improve fallback logging when pull fails
- release Excel/config locks before triggering an update and restore them if the update fails to avoid stale locks

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68c93c95f3e08320834bdb5628329f07